### PR TITLE
Resolve data race issues with concurrent field evaluation & added benchmark tests

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,220 @@
+package graphql_test
+
+import (
+	"testing"
+
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/testutil"
+)
+
+// to avoid possible compiler optimization
+var benchmark_result *graphql.Result
+
+func benchmarkQuery(b *testing.B, schema graphql.Schema, query string) {
+	params := graphql.Params{
+		Schema:        testutil.StarWarsSchema,
+		RequestString: query,
+	}
+
+	var result *graphql.Result
+	for n := 0; n < b.N; n++ {
+		result = graphql.Do(params)
+	}
+	benchmark_result = result
+}
+
+func BenchmarkQuery_BasicQuery(b *testing.B) {
+	query := `
+		{
+			hero {
+				name
+			}
+		}
+	`
+	benchmarkQuery(b, testutil.StarWarsSchema, query)
+}
+
+func BenchmarkQuery_BasicQueryWithList(b *testing.B) {
+	query := `
+		{
+			hero {
+				id
+				name
+				friends {
+					id
+					name
+				}
+				appearsIn
+			}
+		}
+	`
+	benchmarkQuery(b, testutil.StarWarsSchema, query)
+}
+
+func BenchmarkQuery_DeeperQueryWithList(b *testing.B) {
+	query := `
+		{
+			hero {
+				id
+				name
+				friends {
+					id
+					name
+					friends {
+						id
+						name
+						appearsIn
+					}
+					appearsIn
+				}
+				appearsIn
+			}
+		}
+	`
+	benchmarkQuery(b, testutil.StarWarsSchema, query)
+}
+
+func BenchmarkQuery_QueryWithManyRootFieldsAndList(b *testing.B) {
+	query := `
+		{
+			hero {
+				id
+				name
+				friends {
+					name
+				}
+				appearsIn
+			}
+			vader: human(id: "1001") {
+				id
+				name
+				friends {
+					id
+					name
+					appearsIn
+				}
+				appearsIn
+				homePlanet
+			}
+			leia: human(id: "1003") {
+				id
+				name
+				friends {
+					id
+					name
+					appearsIn
+				}
+				appearsIn
+				homePlanet
+			}
+			threepio: droid(id: "2000") {
+				id
+				name
+				friends {
+					id
+					name
+					appearsIn
+				}
+				appearsIn
+				PrimaryFunction
+			}
+			artoo: droid(id: "2001") {
+				id
+				name
+				friends {
+					id
+					name
+					appearsIn
+				}
+				appearsIn
+				PrimaryFunction
+			}
+		}
+	`
+	benchmarkQuery(b, testutil.StarWarsSchema, query)
+}
+
+func BenchmarkQuery_DeeperQueryWithManyRootFieldsAndList(b *testing.B) {
+	query := `
+		{
+			hero {
+				id
+				name
+				friends {
+					name
+					friends {
+						id
+						name
+						appearsIn
+					}
+				}
+				appearsIn
+			}
+			vader: human(id: "1001") {
+				id
+				name
+				friends {
+					id
+					name
+					appearsIn
+					friends {
+						id
+						name
+						appearsIn
+					}
+				}
+				appearsIn
+				homePlanet
+			}
+			leia: human(id: "1003") {
+				id
+				name
+				friends {
+					id
+					name
+					appearsIn
+					friends {
+						id
+						name
+						appearsIn
+					}
+				}
+				appearsIn
+				homePlanet
+			}
+			threepio: droid(id: "2000") {
+				id
+				name
+				friends {
+					id
+					name
+					appearsIn
+					friends {
+						id
+						name
+						appearsIn
+					}
+				}
+				appearsIn
+				PrimaryFunction
+			}
+			artoo: droid(id: "2001") {
+				id
+				name
+				friends {
+					id
+					name
+					appearsIn
+					friends {
+						id
+						name
+						appearsIn
+					}
+				}
+				appearsIn
+				PrimaryFunction
+			}
+		}
+	`
+	benchmarkQuery(b, testutil.StarWarsSchema, query)
+}

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -196,7 +196,7 @@ func BenchmarkQuery_DeeperQueryWithManyRootFieldsAndList(b *testing.B) {
 					}
 				}
 				appearsIn
-				PrimaryFunction
+				primaryFunction
 			}
 			artoo: droid(id: "2001") {
 				id
@@ -212,7 +212,7 @@ func BenchmarkQuery_DeeperQueryWithManyRootFieldsAndList(b *testing.B) {
 					}
 				}
 				appearsIn
-				PrimaryFunction
+				primaryFunction
 			}
 		}
 	`

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -116,7 +116,7 @@ func BenchmarkQuery_QueryWithManyRootFieldsAndList(b *testing.B) {
 					appearsIn
 				}
 				appearsIn
-				PrimaryFunction
+				primaryFunction
 			}
 			artoo: droid(id: "2001") {
 				id
@@ -127,7 +127,7 @@ func BenchmarkQuery_QueryWithManyRootFieldsAndList(b *testing.B) {
 					appearsIn
 				}
 				appearsIn
-				PrimaryFunction
+				primaryFunction
 			}
 		}
 	`

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -69,6 +69,170 @@ func init() {
 				},
 			},
 		},
+		{
+			Query: `
+				{
+					hero {
+						id
+						name
+						friends {
+							name
+						}
+						appearsIn
+					}
+					vader: human(id: "1001") {
+						id
+						name
+						friends {
+							id
+							name
+							appearsIn
+						}
+						appearsIn
+						homePlanet
+					}
+					threepio: droid(id: "2000") {
+						id
+						name
+						friends {
+							id
+							name
+							appearsIn
+						}
+						appearsIn
+						primaryFunction
+					}
+				}
+			`,
+			Schema: testutil.StarWarsSchema,
+			Expected: &graphql.Result{
+				Data: map[string]interface{}{
+					"threepio": map[string]interface{}{
+						"primaryFunction": "Protocol",
+						"id":              "2000",
+						"appearsIn": []interface{}{
+							"NEWHOPE",
+							"EMPIRE",
+							"JEDI",
+						},
+						"name": "C-3PO",
+						"friends": []interface{}{
+							map[string]interface{}{
+								"id":   "1000",
+								"name": "Luke Skywalker",
+								"appearsIn": []interface{}{
+									"NEWHOPE",
+									"EMPIRE",
+									"JEDI",
+								},
+							},
+							map[string]interface{}{
+								"name": "Han Solo",
+								"id":   "1002",
+								"appearsIn": []interface{}{
+									"NEWHOPE",
+									"EMPIRE",
+									"JEDI",
+								},
+							},
+							map[string]interface{}{
+								"name": "Leia Organa",
+								"appearsIn": []interface{}{
+									"NEWHOPE",
+									"EMPIRE",
+									"JEDI",
+								},
+								"id": "1003",
+							},
+							map[string]interface{}{
+								"appearsIn": []interface{}{
+									"NEWHOPE",
+									"EMPIRE",
+									"JEDI",
+								},
+								"id":   "2001",
+								"name": "R2-D2",
+							},
+						},
+					},
+					"vader": map[string]interface{}{
+						"id": "1001",
+						"appearsIn": []interface{}{
+							"NEWHOPE",
+							"EMPIRE",
+							"JEDI",
+						},
+						"friends": []interface{}{
+							map[string]interface{}{
+								"appearsIn": []interface{}{
+									"NEWHOPE",
+									"EMPIRE",
+									"JEDI",
+								},
+								"name": "Han Solo",
+								"id":   "1002",
+							},
+							map[string]interface{}{
+								"id":   "1003",
+								"name": "Leia Organa",
+								"appearsIn": []interface{}{
+									"NEWHOPE",
+									"EMPIRE",
+									"JEDI",
+								},
+							},
+							map[string]interface{}{
+								"id":   "2000",
+								"name": "C-3PO",
+								"appearsIn": []interface{}{
+									"NEWHOPE",
+									"EMPIRE",
+									"JEDI",
+								},
+							},
+							map[string]interface{}{
+								"id": "2001",
+								"appearsIn": []interface{}{
+									"NEWHOPE",
+									"EMPIRE",
+									"JEDI",
+								},
+								"name": "R2-D2",
+							},
+							map[string]interface{}{
+								"appearsIn": []interface{}{
+									"NEWHOPE",
+								},
+								"id":   "1004",
+								"name": "Wilhuff Tarkin",
+							},
+						},
+						"homePlanet": "Tatooine",
+						"name":       "Darth Vader",
+					},
+					"hero": map[string]interface{}{
+						"name": "R2-D2",
+						"id":   "2001",
+						"appearsIn": []interface{}{
+							"NEWHOPE",
+							"EMPIRE",
+							"JEDI",
+						},
+						"friends": []interface{}{
+							map[string]interface{}{
+								"name": "Luke Skywalker",
+							},
+							map[string]interface{}{
+								"name": "Han Solo",
+							},
+							map[string]interface{}{
+								"name": "Leia Organa",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/schema.go
+++ b/schema.go
@@ -36,7 +36,7 @@ type Schema struct {
 	possibleTypeMap  map[string]map[string]bool
 
 	// mutex lock for possibleTypeMap that is accessed by multiple routines in executor through IsPossibleType()
-	typeMapMutex sync.RWMutex
+	typeMapMutex *sync.RWMutex
 }
 
 func NewSchema(config SchemaConfig) (Schema, error) {
@@ -45,7 +45,7 @@ func NewSchema(config SchemaConfig) (Schema, error) {
 	schema := Schema{
 		implementations: map[string][]*Object{},
 		possibleTypeMap: map[string]map[string]bool{},
-		typeMapMutex:    sync.RWMutex{},
+		typeMapMutex:    &sync.RWMutex{},
 	}
 
 	err = invariant(config.Query != nil, "Schema query must be Object Type but got: nil.")

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"encoding/json"
 	"reflect"
-	"strconv"
 	"testing"
 	"time"
 
@@ -21,8 +20,8 @@ var (
 	Tarkin         StarWarsChar
 	Threepio       StarWarsChar
 	Artoo          StarWarsChar
-	HumanData      map[int]StarWarsChar
-	DroidData      map[int]StarWarsChar
+	HumanData      map[string]StarWarsChar
+	DroidData      map[string]StarWarsChar
 	StarWarsSchema graphql.Schema
 
 	humanType *graphql.Object
@@ -86,16 +85,16 @@ func init() {
 	Tarkin.Friends = append(Tarkin.Friends, []StarWarsChar{Vader}...)
 	Threepio.Friends = append(Threepio.Friends, []StarWarsChar{Luke, Han, Leia, Artoo}...)
 	Artoo.Friends = append(Artoo.Friends, []StarWarsChar{Luke, Han, Leia}...)
-	HumanData = map[int]StarWarsChar{
-		1000: Luke,
-		1001: Vader,
-		1002: Han,
-		1003: Leia,
-		1004: Tarkin,
+	HumanData = map[string]StarWarsChar{
+		"1000": Luke,
+		"1001": Vader,
+		"1002": Han,
+		"1003": Leia,
+		"1004": Tarkin,
 	}
-	DroidData = map[int]StarWarsChar{
-		2000: Threepio,
-		2001: Artoo,
+	DroidData = map[string]StarWarsChar{
+		"2000": Threepio,
+		"2001": Artoo,
 	}
 
 	episodeEnum := graphql.NewEnum(graphql.EnumConfig{
@@ -136,8 +135,7 @@ func init() {
 		},
 		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
 			if character, ok := p.Value.(StarWarsChar); ok {
-				id, _ := strconv.Atoi(character.ID)
-				human := GetHuman(id)
+				human := GetHuman(character.ID)
 				if human.ID != "" {
 					return humanType
 				}
@@ -301,7 +299,7 @@ func init() {
 					},
 				},
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					return GetHuman(p.Args["id"].(int)), nil
+					return GetHuman(p.Args["id"].(string)), nil
 				},
 			},
 			"droid": &graphql.Field{
@@ -313,7 +311,7 @@ func init() {
 					},
 				},
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					return GetDroid(p.Args["id"].(int)), nil
+					return GetDroid(p.Args["id"].(string)), nil
 				},
 			},
 		},
@@ -323,14 +321,14 @@ func init() {
 	})
 }
 
-func GetHuman(id int) StarWarsChar {
+func GetHuman(id string) StarWarsChar {
 	time.Sleep(1 * time.Millisecond)
 	if human, ok := HumanData[id]; ok {
 		return human
 	}
 	return StarWarsChar{}
 }
-func GetDroid(id int) StarWarsChar {
+func GetDroid(id string) StarWarsChar {
 	time.Sleep(1 * time.Millisecond)
 	if droid, ok := DroidData[id]; ok {
 		return droid

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/language/ast"
@@ -323,18 +324,21 @@ func init() {
 }
 
 func GetHuman(id int) StarWarsChar {
+	time.Sleep(1 * time.Millisecond)
 	if human, ok := HumanData[id]; ok {
 		return human
 	}
 	return StarWarsChar{}
 }
 func GetDroid(id int) StarWarsChar {
+	time.Sleep(1 * time.Millisecond)
 	if droid, ok := DroidData[id]; ok {
 		return droid
 	}
 	return StarWarsChar{}
 }
 func GetHero(episode interface{}) interface{} {
+	time.Sleep(1 * time.Millisecond)
 	if episode == 5 {
 		return Luke
 	}


### PR DESCRIPTION
Follow up to PR #20 and #21 

Resolve data race issues and added initial benchmark tests
- Protect shared fields across routines for `Object`, `Enum` and `Schema`
- Discovered through `go test ./... -race`
- Standardise mutex field names *Mutex
- Some optimisation in lazy-eval functions in `Enum. getValueLookup()` and `Schema.IsPossibleType()`

/cc @andreas @chris-ramon @mleonard87
