### PR TITLE
Opt-in parallel resolving of fields and lists

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -539,6 +539,7 @@ func defineFieldMap(ttype Named, fields Fields) (FieldDefinitionMap, error) {
 			Type:              field.Type,
 			Resolve:           field.Resolve,
 			DeprecationReason: field.DeprecationReason,
+			Parallel:          field.Parallel,
 		}
 
 		fieldDef.Args = []*Argument{}
@@ -614,6 +615,7 @@ type Field struct {
 	Resolve           FieldResolveFn
 	DeprecationReason string `json:"deprecationReason"`
 	Description       string `json:"description"`
+	Parallel          bool
 }
 
 type FieldConfigArgument map[string]*ArgumentConfig
@@ -632,6 +634,7 @@ type FieldDefinition struct {
 	Args              []*Argument    `json:"args"`
 	Resolve           FieldResolveFn `json:"-"`
 	DeprecationReason string         `json:"deprecationReason"`
+	Parallel          bool
 }
 
 type FieldArgument struct {
@@ -1197,7 +1200,8 @@ func (gt *InputObject) Error() error {
 //     })
 //
 type List struct {
-	OfType Type `json:"ofType"`
+	OfType   Type `json:"ofType"`
+	Parallel bool
 
 	err error
 }


### PR DESCRIPTION
Following the discussion in https://github.com/graphql-go/graphql/pull/132 I've tried to implement opt-in parallel resolving of fields and lists.

A field is resolved in a goroutine if `Parallel` on the field is true:

``` go
var fooType = graphql.NewObect(graphql.ObjectConfig{
  Name: "Foo",
  Fields: graphql.Fields{
    "name": &graphq.Field{
      Type: graphql.String,
    },
    "heavyQuery": &graphql.Field{
      Type: graphql.Int,
      Parallel: true,
      Resolve: func(p graphql.ResolveParams) (interface{}, error) {
        // make heavy query here
      },
    },
    "slowNetworkCall": &graphql.Field{
      Type: graphql.String,
      Parallel: true,
      Resolve: func(p graphql.ResolveParams) (interface{}, error) {
        // make slow network call here
      },
    },
  }
})
```

Each element of a list is resolved in a goroutine if `Parallel` on the list is true:

``` go
var fooList := graphql.NewList(fooType)
fooList.Parallel = true
```
## Next
- [ ] Verify approach
- [ ] Benchmark
- [ ] Add tests
